### PR TITLE
Remove/unit of measurement

### DIFF
--- a/custom_components/eyeonwater/config_flow.py
+++ b/custom_components/eyeonwater/config_flow.py
@@ -44,7 +44,6 @@ def create_account_from_config(
     """Create account login from config."""
     eow_hostname = get_hostname_for_country(hass)
 
-    metric_measurement_system = hass.config.units is METRIC_SYSTEM
     username = data[CONF_USERNAME]
     password = data[CONF_PASSWORD]
 
@@ -52,7 +51,6 @@ def create_account_from_config(
         eow_hostname=eow_hostname,
         username=username,
         password=password,
-        metric_measurement_system=metric_measurement_system,
     )
 
 

--- a/custom_components/eyeonwater/sensor.py
+++ b/custom_components/eyeonwater/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.recorder.statistics import (
     get_last_statistics,
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, UnitOfVolume
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -122,7 +122,6 @@ class EyeOnWaterSensor(CoordinatorEntity, SensorEntity):
         self._state = None
         self._available = False
         self._attr_unique_id = meter.meter_uuid
-        self._attr_native_unit_of_measurement = meter.native_unit_of_measurement
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.meter.meter_uuid)},
             name=f"{WATER_METER_NAME} {self.meter.meter_id}",
@@ -143,6 +142,14 @@ class EyeOnWaterSensor(CoordinatorEntity, SensorEntity):
     def native_value(self):
         """Get the latest reading."""
         return self._state
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        """Get the unit of measurement from reading."""
+        if self.meter.meter_info.reading.latest_read.units == "GAL":
+            return UnitOfVolume.GALLONS
+        else:
+            return UnitOfVolume.MILLILITERS
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
This PR will remove all need for us to determine what to display for the user. By reading the unit given to us by the API and telling HA what the NATIVE reading is, HA will automatically calculate and display the proper unit to the user.