### PR TITLE
Adopt pyonwater export path for manual imports

### DIFF
--- a/custom_components/eyeonwater/coordinator.py
+++ b/custom_components/eyeonwater/coordinator.py
@@ -127,6 +127,26 @@ class EyeOnWaterData:
         )
         return volume_conversion_factor(native_unit, display_unit)
 
+    def _get_export_unit(self, meter: Meter) -> str:
+        """Return export-unit label matching the meter native unit."""
+        native_unit = getattr(
+            meter.native_unit_of_measurement,
+            "value",
+            str(meter.native_unit_of_measurement),
+        )
+        export_unit = {
+            "gal": "Gallons",
+            "cf": "Cubic Feet",
+            "cm": "Cubic Meters",
+        }.get(native_unit)
+        if export_unit is None:
+            _LOGGER.warning(
+                "Unsupported native unit %s for export-range import; defaulting export_unit to Gallons",
+                meter.native_unit_of_measurement,
+            )
+            return "Gallons"
+        return export_unit
+
     def _import_meter_statistics(self, meter: Meter) -> None:
         """Filter and import new historical data points for a meter."""
         if not meter.last_historical_data:
@@ -182,10 +202,19 @@ class EyeOnWaterData:
         """Import historical data (service call)."""
         for meter in self.meters:
             try:
-                data = await meter.read_historical_data(
-                    client=self.client,
-                    days_to_load=days,
-                )
+                if days > 1:
+                    # Export range is the bulk multi-day retrieval path; single-day
+                    # imports stay on the regular per-day consumption endpoint.
+                    data = await meter.read_historical_data_range_export(
+                        client=self.client,
+                        days_to_load=days,
+                        export_unit=self._get_export_unit(meter),
+                    )
+                else:
+                    data = await meter.read_historical_data(
+                        client=self.client,
+                        days_to_load=days,
+                    )
             except Exception as exc:  # noqa: BLE001
                 _LOGGER.warning(
                     "Failed to read historical data for meter %s: %s",

--- a/custom_components/eyeonwater/manifest.json
+++ b/custom_components/eyeonwater/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/kdeyev/eyeonwater/issues",
   "requirements": ["pyonwater==0.3.32"],
-"version": "2.7.8"
+"version": "2.7.9-beta.1"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ def _make_meter(
     meter.last_historical_data = [FakeDataPoint()]
     meter.read_meter_info = AsyncMock()
     meter.read_historical_data = AsyncMock(return_value=[FakeDataPoint()])
+    meter.read_historical_data_range_export = AsyncMock(return_value=[FakeDataPoint()])
     return meter
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -159,10 +159,49 @@ async def test_import_historical_data(eow_data) -> None:
     ) as mock_import:
         await eow_data.import_historical_data(days=30)
 
-    eow_data.meters[0].read_historical_data.assert_awaited()
+    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once()
+    eow_data.meters[0].read_historical_data.assert_not_awaited()
     call_args = mock_import.call_args[0]
     assert len(call_args) == 3  # (hass, metadata, statistics)
     assert len(call_args[2]) > 0  # at least one StatisticData row passed
+
+
+@pytest.mark.asyncio
+async def test_import_historical_data_days_gt_one_uses_export_path(eow_data) -> None:
+    """Manual import uses export-range path when requesting multiple days."""
+    with patch(
+        "custom_components.eyeonwater.coordinator.get_last_imported_time",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await eow_data.setup()
+
+    with patch(
+        "custom_components.eyeonwater.coordinator.async_add_external_statistics",
+    ):
+        await eow_data.import_historical_data(days=2)
+
+    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once()
+    eow_data.meters[0].read_historical_data.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_historical_data_one_day_uses_regular_path(eow_data) -> None:
+    """Manual import keeps the regular path for a single day."""
+    with patch(
+        "custom_components.eyeonwater.coordinator.get_last_imported_time",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await eow_data.setup()
+
+    with patch(
+        "custom_components.eyeonwater.coordinator.async_add_external_statistics",
+    ):
+        await eow_data.import_historical_data(days=1)
+
+    eow_data.meters[0].read_historical_data.assert_awaited_once()
+    eow_data.meters[0].read_historical_data_range_export.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -292,6 +331,8 @@ async def test_import_historical_data_includes_cost_stats(eow_data) -> None:
     ) as mock_import:
         await eow_data.import_historical_data(days=30)
 
+    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once()
+    eow_data.meters[0].read_historical_data.assert_not_awaited()
     # Water + cost
     assert mock_import.call_count == 2
 
@@ -361,6 +402,8 @@ async def test_import_historical_data_uses_display_unit(eow_data) -> None:
     ) as mock_import:
         await eow_data.import_historical_data(days=30)
 
+    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once()
+    eow_data.meters[0].read_historical_data.assert_not_awaited()
     mock_import.assert_called_once()
     metadata = mock_import.call_args[0][1]
     assert metadata["unit_of_measurement"] == "m\u00b3"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -159,8 +159,6 @@ async def test_import_historical_data(eow_data) -> None:
     ) as mock_import:
         await eow_data.import_historical_data(days=30)
 
-    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once()
-    eow_data.meters[0].read_historical_data.assert_not_awaited()
     call_args = mock_import.call_args[0]
     assert len(call_args) == 3  # (hass, metadata, statistics)
     assert len(call_args[2]) > 0  # at least one StatisticData row passed
@@ -181,8 +179,12 @@ async def test_import_historical_data_days_gt_one_uses_export_path(eow_data) -> 
     ):
         await eow_data.import_historical_data(days=2)
 
-    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once()
     eow_data.meters[0].read_historical_data.assert_not_awaited()
+    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once_with(
+        client=eow_data.client,
+        days_to_load=2,
+        export_unit="Gallons",
+    )
 
 
 @pytest.mark.asyncio
@@ -202,6 +204,32 @@ async def test_import_historical_data_one_day_uses_regular_path(eow_data) -> Non
 
     eow_data.meters[0].read_historical_data.assert_awaited_once()
     eow_data.meters[0].read_historical_data_range_export.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_import_historical_data_days_gt_one_uses_native_export_unit(
+    eow_data,
+) -> None:
+    """Multi-day import forwards export_unit matching meter native units."""
+    with patch(
+        "custom_components.eyeonwater.coordinator.get_last_imported_time",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await eow_data.setup()
+
+    eow_data.meters[0].native_unit_of_measurement = "cf"
+
+    with patch(
+        "custom_components.eyeonwater.coordinator.async_add_external_statistics",
+    ):
+        await eow_data.import_historical_data(days=3)
+
+    eow_data.meters[0].read_historical_data_range_export.assert_awaited_once_with(
+        client=eow_data.client,
+        days_to_load=3,
+        export_unit="Cubic Feet",
+    )
 
 
 @pytest.mark.asyncio
@@ -347,8 +375,10 @@ async def test_import_historical_data_continues_on_api_error(eow_data) -> None:
     ):
         await eow_data.setup()
 
-    eow_data.meters[0].read_historical_data.side_effect = EyeOnWaterAPIError(
-        "empty response",
+    eow_data.meters[0].read_historical_data_range_export.side_effect = (
+        EyeOnWaterAPIError(
+            "empty response",
+        )
     )
 
     with patch(


### PR DESCRIPTION
## Summary
- bump eyeonwater to pyonwater 0.3.28
- use Meter.read_historical_data_range_export(...) for manual history imports when more than one day is requested
- keep one-day manual imports on the existing Meter.read_historical_data(...) path
- update coordinator fixtures and tests for export vs regular path selection

## Notes
- this PR intentionally changes only the fetch path inside import_historical_data(days)
- display-unit handling, metadata generation, statistics conversion, and cost-stat imports are unchanged

## Testing
- python -m py_compile custom_components/eyeonwater/coordinator.py tests/conftest.py tests/test_coordinator.py
- pytest could not run in this local clone because homeassistant is not installed in the environment