### PR TITLE
fix: catch all exceptions in coordinator to prevent sensor unavailability

### DIFF
--- a/custom_components/eyeonwater/coordinator.py
+++ b/custom_components/eyeonwater/coordinator.py
@@ -11,7 +11,6 @@ from pyonwater import (
     Account,
     Client,
     DataPoint,
-    EyeOnWaterException,
     Meter,
 )
 
@@ -84,7 +83,7 @@ class EyeOnWaterData:
         for meter in self.meters:
             try:
                 await meter.read_meter_info(client=self.client)
-            except (EyeOnWaterException, TimeoutError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001
                 _LOGGER.warning(
                     "Failed to refresh meter info for %s, using cached data: %s",
                     meter.meter_id,
@@ -96,14 +95,21 @@ class EyeOnWaterData:
                     client=self.client,
                     days_to_load=days_to_load,
                 )
-            except (EyeOnWaterException, TimeoutError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001
                 _LOGGER.warning(
                     "Failed to read historical data for %s: %s",
                     meter.meter_id,
                     exc,
                 )
 
-            self._import_meter_statistics(meter)
+            try:
+                self._import_meter_statistics(meter)
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Failed to import statistics for %s: %s",
+                    meter.meter_id,
+                    exc,
+                )
 
         return self.meters
 
@@ -180,11 +186,11 @@ class EyeOnWaterData:
                     client=self.client,
                     days_to_load=days,
                 )
-            except EyeOnWaterException as error:
+            except Exception as exc:  # noqa: BLE001
                 _LOGGER.warning(
                     "Failed to read historical data for meter %s: %s",
                     meter.meter_id,
-                    error,
+                    exc,
                 )
                 continue
 
@@ -197,9 +203,16 @@ class EyeOnWaterData:
                 len(data),
                 meter.meter_id,
             )
-            factor = self._get_volume_factor(meter)
-            statistics = convert_statistic_data(data, factor)
-            metadata = get_statistic_metadata(meter, self._get_display_unit())
-            async_add_external_statistics(self.hass, metadata, statistics)
+            try:
+                factor = self._get_volume_factor(meter)
+                statistics = convert_statistic_data(data, factor)
+                metadata = get_statistic_metadata(meter, self._get_display_unit())
+                async_add_external_statistics(self.hass, metadata, statistics)
 
-            self._import_cost_statistics(meter, data)
+                self._import_cost_statistics(meter, data)
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Failed to import statistics for meter %s: %s",
+                    meter.meter_id,
+                    exc,
+                )

--- a/custom_components/eyeonwater/manifest.json
+++ b/custom_components/eyeonwater/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/kdeyev/eyeonwater/issues",
   "requirements": ["pyonwater==0.3.32"],
-"version": "2.7.7"
+"version": "2.7.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "eyeonwater"
-version = "2.7.7"
+version = "2.7.8"
 description = "EyeOnWater HomeAssistant Integration."
 authors = []
 license = "MIT"


### PR DESCRIPTION
Wrap every operation in read_meters() and import_historical_data() with except Exception (noqa: BLE001) so no uncaught exception can crash the coordinator and make sensors unavailable.

Previously only EyeOnWaterException was caught, leaving TimeoutError, OSError, HomeAssistantError, and other exceptions unhandled. This caused intermittent sensor unavailability that was impossible to prevent by catching specific types one at a time.

Changes:
- read_meters: wrap read_meter_info, read_historical_data, and _import_meter_statistics each in except Exception
- import_historical_data: wrap read_historical_data and the statistics import block each in except Exception
- Remove unused EyeOnWaterException import from coordinator